### PR TITLE
Refaktorering av play/marker logikk

### DIFF
--- a/js/controllers/alerts-controller.js
+++ b/js/controllers/alerts-controller.js
@@ -42,15 +42,11 @@ angular.module('radio')
         break;
     }
     
-    $scope.$apply(function() {
-      $scope.alerts.position = alert;
-    });
+    $scope.alerts.position = alert;
   });
   
   $scope.$on('position:updated', function(event, pos) {
-    $scope.$apply(function() {
-      delete $scope.alerts.position;
-    });
+    delete $scope.alerts.position;
   });
   
   $scope.$on('position:ended', function(event, pos) {

--- a/js/controllers/map-controller.js
+++ b/js/controllers/map-controller.js
@@ -105,23 +105,18 @@ angular.module('radio')
   
   // Observers
   $scope.$on('position:updated', function(event, pos) {
-    $scope.$apply(function() {
-      updateCurrentLocation(pos.latitude, pos.longitude);
-    });
+    updateCurrentLocation(pos.latitude, pos.longitude);
   });
   
   $scope.$on('player:clipStarted', function(event, clip) {
-    $scope.$apply(function() {
-      $scope.map.markers[clip.id].icon = playingIcon;
-    });
+    $scope.map.markers[clip.id].icon = playingIcon;
   });
   
   $scope.$on('player:clipEnded', function(event, clip) {
-    $scope.$apply(function() {
-      angular.forEach($scope.map.markers, function(marker) {
-        if(marker.icon == playingIcon)
-          marker.icon = pausedIcon;
-      });
+    angular.forEach($scope.map.markers, function(marker) {
+      if(marker.icon == playingIcon)
+        marker.icon = pausedIcon;
+      }
     });
   });
 

--- a/js/controllers/map-controller.js
+++ b/js/controllers/map-controller.js
@@ -111,18 +111,22 @@ angular.module('radio')
   });
   
   $scope.$on('player:clipStarted', function(event, clip) {
-    $scope.map.markers[clip.id].icon = playingIcon;
+    var markers = angular.extend({}, $scope.map.markers);
+    angular.forEach(markers, function (marker) {
+      if (marker === markers[clip.id]) {
+        marker.icon = playingIcon;
+      } else if (marker.icon === playingIcon) {
+        marker.icon = pausedIcon;
+      }
+    });
+    $scope.map.markers = markers;
   });
   
   $scope.$on('player:clipEnded', function(event, clip) {
-    var markers = [];
-    angular.forEach($scope.map.markers, function(marker) {
-      if(marker.icon == playingIcon) {
-        markers.push(angular.extend({}, marker, {
-            icon: pausedIcon
-        }));
-      } else {
-          markers.push(marker);
+    var markers = angular.extend({}, $scope.map.markers);
+    angular.forEach(markers, function(marker) {
+      if(marker.icon === playingIcon) {
+        marker.icon = pausedIcon;
       }
     });
     $scope.map.markers = markers;

--- a/js/controllers/map-controller.js
+++ b/js/controllers/map-controller.js
@@ -76,11 +76,13 @@ angular.module('radio')
   }
   
   function updateCurrentLocation(lat, lng) {
-    $scope.map.markers.currentLocation = {
-      lat: lat,
-      lng: lng,
-      icon: locationIcon
-    };
+    $scope.map.markers = angular.extend({}, $scope.map.markers, {
+      currentLocation: {
+        lat: lat,
+        lng: lng,
+        icon: locationIcon
+       }
+    });
   }
   
   function addClipMarker(clip) {
@@ -113,11 +115,17 @@ angular.module('radio')
   });
   
   $scope.$on('player:clipEnded', function(event, clip) {
+    var markers = [];
     angular.forEach($scope.map.markers, function(marker) {
-      if(marker.icon == playingIcon)
-        marker.icon = pausedIcon;
+      if(marker.icon == playingIcon) {
+        markers.push(angular.extend({}, marker, {
+            icon: pausedIcon
+        }));
+      } else {
+          markers.push(marker);
       }
     });
+    $scope.map.markers = markers;
   });
 
   $scope.$on('player:tripStarted', function(event) {

--- a/js/services/audio-service.js
+++ b/js/services/audio-service.js
@@ -51,38 +51,47 @@ angular.module('radio')
   // Observers
   
   audio.addEventListener('canplay', function(evt) {
-    audioIsReady = true;
-    console.log("Audio: can play");
-    $rootScope.$broadcast('audio:canplay');
+    $rootScope.$apply(function () {
+      audioIsReady = true;
+      console.log("Audio: can play");
+      $rootScope.$broadcast('audio:canplay');
+    });
   });
   
   audio.addEventListener('play', function(evt) {
-    console.log("Audio: Play from " + audio.currentTime);
+    $rootScope.$apply(function () {
+      console.log("Audio: Play from " + audio.currentTime);
+    });
   });
 
   audio.addEventListener('playing', function(evt) {
-    console.log("Audio: Playing from " + audio.currentTime);
-    console.log(evt);
+    $rootScope.$apply(function () {
+      console.log("Audio: Playing from " + audio.currentTime);
+      console.log(evt);
+    });
   });
 
   audio.addEventListener('pause', function(evt) {
-    console.log("Audio: Pause at " + audio.currentTime);
+    $rootScope.$apply(function () {
+      console.log("Audio: Pause at " + audio.currentTime);
+    });
   });
 
   audio.addEventListener('ended', function(evt) {
-    console.log("Audio: Ended at " + audio.currentTime);
+    $rootScope.$apply(function () {
+      console.log("Audio: Ended at " + audio.currentTime);
+    });
   });
 
   audio.addEventListener('timeupdate', function(evt) {
-    if(!currentSprite)
-      return;
-    
-    if (audio.currentTime >= currentSprite.end) {
-      pauseAudio();
-      currentSprite = null;
-      console.log("Audio: Sprite ended");
-      $rootScope.$broadcast('audio:spriteEnded');
-    }
+    $rootScope.$apply(function () {
+      if (currentSprite && audio.currentTime >= currentSprite.end) {
+        pauseAudio();
+        currentSprite = null;
+        console.log("Audio: Sprite ended");
+        $rootScope.$broadcast('audio:spriteEnded');
+      }
+    });
   });
 
   return {

--- a/js/services/audio-service.js
+++ b/js/services/audio-service.js
@@ -1,10 +1,10 @@
 angular.module('radio')
 
-.factory('Audio', function($document, $rootScope) {
+.factory('Audio', function($document, $rootScope, $q) {
   
   var audio = $document[0].createElement('audio');
   
-  var audioIsReady = false;
+  var audioIsReady = $q.defer();
   var currentSprite = null;
 
   var isSpriteCurrentSprite = function(sprite) {
@@ -14,7 +14,9 @@ angular.module('radio')
   var setAudioSrc = function(src) {
     pauseAudio();
     currentSprite = null;
-    audioIsReady = false;
+
+    audioIsReady.reject();
+    audioIsReady = $q.defer();
     
     if(src) {
       audio.src = src;
@@ -52,9 +54,7 @@ angular.module('radio')
   
   audio.addEventListener('canplay', function(evt) {
     $rootScope.$apply(function () {
-      audioIsReady = true;
-      console.log("Audio: can play");
-      $rootScope.$broadcast('audio:canplay');
+      audioIsReady.resolve();
     });
   });
   
@@ -100,7 +100,7 @@ angular.module('radio')
     playAudio: playAudio,
     pauseAudio: pauseAudio,
     isReady: function() {
-      return audioIsReady;
+      return audioIsReady.promise;
     }
   };
 

--- a/js/services/locator-service.js
+++ b/js/services/locator-service.js
@@ -6,12 +6,14 @@ angular.module('radio')
   var pos = null;
 
   var setAndBroadcastNewPosition = function (newPos) {
-    pos = {
-      latitude: newPos.coords.latitude,
-      longitude: newPos.coords.longitude
-    };
-    console.log('Locator: Position updated');
-    $rootScope.$broadcast('position:updated', pos);
+    $rootScope.$apply(function () {
+      pos = {
+        latitude: newPos.coords.latitude,
+        longitude: newPos.coords.longitude
+      };
+      console.log('Locator: Position updated');
+      $rootScope.$broadcast('position:updated', pos);
+    });
   };
 
   var broadcastError = function (error) {
@@ -47,8 +49,11 @@ angular.module('radio')
   };
 
   var errorHandler = function(err) {
-    if(watchID)
-      broadcastError(err);
+    if (watchID) {
+      $rootScope.$apply(function () {
+        broadcastError(err);
+      });
+    }
   };
 
   var watchPosition = function() {

--- a/js/services/player-service.js
+++ b/js/services/player-service.js
@@ -68,24 +68,22 @@ angular.module('radio')
 
   var findAndPlayClosestClip = function() {
     
-    if(!trip || !Locator.getCurrentPos() || !Audio.isReady())
+    if(!trip || !Locator.getCurrentPos()) {
       return;
+    }
     
     var closestClip = findClosestClip(Locator.getCurrentPos(), trip.clips);
 
     if(closestClip) {
-      playClosestClip(closestClip);
+      Audio.isReady().then(function () {
+        playClosestClip(closestClip);
+      });
     }
   };
 
   //Observers
   
   $rootScope.$on('position:updated', function(event, newPos) {
-    findAndPlayClosestClip();
-  });
-
-  $rootScope.$on('audio:canplay', function(event) {
-    audioReady = true;
     findAndPlayClosestClip();
   });
 

--- a/js/services/player-service.js
+++ b/js/services/player-service.js
@@ -32,19 +32,18 @@ angular.module('radio')
   var findClosestClip = function(pos, clips) {
     var userLatLng = new google.maps.LatLng(pos.latitude, pos.longitude);
     var closestClip = null;
-    var closestDistance = null;
+    var closestDistance = Number.MAX_VALUE;
 
     angular.forEach(clips, function(clip) {
       var clipLatLng = new google.maps.LatLng(clip.locations.play.lat, clip.locations.play.lng);
       var distance = google.maps.geometry.spherical.computeDistanceBetween(userLatLng, clipLatLng);
 
-      if( distance < clip.treshold &&
-         (!closestDistance || distance < closestDistance)) {
+      if (distance < clip.treshold && distance < closestDistance) {
         closestClip = clip;
         closestDistance = distance;
       }
     });
-    
+
     return closestClip;
   };
   


### PR DESCRIPTION
- Wrap broadcasts triggered by browser events, inside $apply function to avoid $apply to be required in broadcast listeners.
- Simplify async logic by using promises when audio is ready to play.
- Ensure only the current playing marker is showing as playing and pause all others.
