### PR TITLE
Code review

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -101,20 +101,33 @@ body {
 }
 
 .map .marker-play-location {
+  display: none;
+}
+
+.map.test-env .marker-play-location {
+  display: block;
+}
+
+.map .marker-play-location {
   filter: grayscale(50%);
   -webkit-filter: grayscale(50%);
-  opacity: 0.5;
+  opacity: 0.2;
 }
 .map .marker-play-location.active {
   filter: grayscale(0%);
   -webkit-filter: grayscale(0%);
-  opacity: 1;
+  opacity: 0.5;
 }
+
 .map .marker-sight {
-  display: none;
+  filter: grayscale(50%);
+  -webkit-filter: grayscale(50%);
+  opacity: 0.5;
 }
 .map .marker-sight.active {
-  display: block;
+  filter: grayscale(0%);
+  -webkit-filter: grayscale(0%);
+  opacity: 1;
 }
 
 .angular-leaflet-map {

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
   </head>
   <body ng-app="radio" ng-controller="ApplicationCtrl" ng-cloak>
     
-    <div class="map" ng-controller="MapCtrl">
+    <div class="map" ng-controller="MapCtrl" ng-class="{'test-env': isTestEnv}">
       
       <leaflet center="map.center" bounds="map.bounds" layers="map.layers" markers="map.markers" defaults="map.defaults"></leaflet>
       

--- a/js/controllers/map-controller.js
+++ b/js/controllers/map-controller.js
@@ -21,9 +21,9 @@ angular.module('radio')
     className: 'marker-play-location'
   },
   activeSightIcon: {
-    iconUrl: '/img/marker_paused.png',
-    iconSize: [26, 26],
-    iconAnchor: [13, 13],
+    iconUrl: '/img/marker_playing.png',
+    iconSize: [50, 50],
+    iconAnchor: [25, 47],
     className: 'marker-sight active'
   },
   inactiveSightIcon: {

--- a/js/controllers/map-controller.js
+++ b/js/controllers/map-controller.js
@@ -9,9 +9,9 @@ angular.module('radio')
     className: 'marker-current-location'
   },
   playingIcon: {
-    iconUrl: '/img/marker_playing.png',
-    iconSize: [50, 50],
-    iconAnchor: [25, 47],
+    iconUrl: '/img/marker_paused.png',
+    iconSize: [26, 26],
+    iconAnchor: [13, 13], 
     className: 'marker-play-location active'
   },
   pausedIcon: {
@@ -38,9 +38,10 @@ angular.module('radio')
     type: 'xyz'
   }
 })
-.controller('MapCtrl', function(_, $scope, $timeout, Locator, MapUtil, Player, MarkerIcons) {
+.controller('MapCtrl', function(_, $scope, $timeout, Locator, MapUtil, Player, MarkerIcons, environment) {
   var osloBounds = MapUtil.calculateBoundsForOslo();
   
+  $scope.isTestEnv = !environment.isProduction;
   $scope.showMapControls = false;
   
   $scope.map = {


### PR DESCRIPTION
Fixed in pull request: 
- Play location only visible in test environment
- Active sight use playing.png

TODO @knutz3n:
- Sights should only be active when talked about.
- Use start_in_clip and end_in_clip. Note these values denote seconds from the beginning of the audio file, not from the beginning of the clip.
